### PR TITLE
Use set for paths-to-update comparison

### DIFF
--- a/src/library.rs
+++ b/src/library.rs
@@ -129,7 +129,7 @@ use rusqlite::Params;
 use rusqlite::Row;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
 use std::fs::create_dir_all;
@@ -661,7 +661,7 @@ impl<Config: AppConfigTrait> Library<Config> {
                     Ok(row.get_unwrap::<usize, String>(0))
                 })?
                 .map(|x| PathBuf::from(x.unwrap()))
-                .collect::<Vec<PathBuf>>();
+                .collect::<HashSet<PathBuf>>();
             return_value
         };
 


### PR DESCRIPTION
With about 140k tracks the update operation takes a long time. A flamegraph shows update_library_convert_extra_info as taking almost all of that time and slice_contains in particular.

With the previous release 0.2.9 updates where very fast and got to the actual analyzing part right away. With 0.3.2 it spends a lot of time before it even gets to analyzing. And it seems to be slower to start up the more songs you have analyzed.

Blissify 0.2.9 seemed to use a HashSet too :)

![image](https://user-images.githubusercontent.com/7419144/195966191-c59328cf-6f2a-4ecf-b183-30f8bf2210e4.png)
