### PR TITLE
Update decoder.rs

### DIFF
--- a/src/song/decoder.rs
+++ b/src/song/decoder.rs
@@ -455,12 +455,22 @@ pub mod ffmpeg {
                                 e
                             ))
                         })?;
+                
+                 // Define a constant for the `safe` value based on the feature flags
+                #[cfg(feature = "ffmpeg_6_0")]
+                const SAFE: bool = false;
+                
+                #[cfg(not(feature = "ffmpeg_6_0"))]
+                const SAFE: bool = true;        
+                                        
+                        
                 context.set_threading(Config {
                     kind: ThreadingType::Frame,
                     count: 0,
-                    #[cfg(not(feature = "ffmpeg_6_0"))]
-                    safe: true,
+                    safe: SAFE,
                 });
+
+                
                 let decoder = context.decoder().audio().map_err(|e| {
                     BlissError::DecodingError(format!(
                         "when finding decoder for file '{}': {:?}.",


### PR DESCRIPTION
I had following error when compiling on x86

error[E0063]: missing field safe in initializer of Config
   --> /home/volumio/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bliss-audio-0.8.0/src/song/decoder.rs:458:39
    |
458 |                 context.set_threading(Config {
    |                                       ^^^^^^ missing safe