### PR TITLE
Nitpick: check if a file is directory before scanning

### DIFF
--- a/examples/library.rs
+++ b/examples/library.rs
@@ -77,9 +77,12 @@ impl CustomLibrary for Library<Config, Decoder> {
 
         Ok(glob(&pattern.to_string_lossy())?
             .map(|e| fs::canonicalize(e.unwrap()).unwrap())
-            .filter(|e| match mime_guess::from_path(e).first() {
-                Some(m) => m.type_() == "audio",
-                None => false,
+            .filter(|e| match e.is_dir() {
+                true => false,
+                false => match mime_guess::from_path(e).first() {
+                    Some(m) => m.type_() == "audio",
+                    None => false,
+                },
             })
             .map(|x| x.to_string_lossy().to_string())
             .collect::<Vec<String>>())


### PR DESCRIPTION
When getting all songs in the library, ignore all folders. Previously, if you had a folder that was of some file format extension (`$folder.mp3`, `$folder.wav`, etc), it would then pass to ffmpeg (which would complain that it is a directory).