### PR TITLE
fix(library): Use String instead on &str to prevent library playlist panic

### DIFF
--- a/examples/library.rs
+++ b/examples/library.rs
@@ -186,7 +186,7 @@ fn main() -> Result<()> {
         let mut library: Library<Config, Decoder> = Library::from_config_path(config_path)?;
         library.update_library(library.song_paths()?, true, true)?;
     } else if let Some(sub_m) = matches.subcommand_matches("playlist") {
-        let song_path = sub_m.get_one::<&str>("SONG_PATH").unwrap();
+        let song_path = sub_m.get_one::<String>("SONG_PATH").unwrap();
         let config_path = sub_m.get_one::<String>("config-path").map(PathBuf::from);
         let playlist_length = sub_m.get_one("playlist-length").unwrap();
         let library: Library<Config, Decoder> = Library::from_config_path(config_path)?;

--- a/examples/library_extra_info.rs
+++ b/examples/library_extra_info.rs
@@ -204,7 +204,7 @@ fn main() -> Result<()> {
         let mut library: Library<Config, Decoder> = Library::from_config_path(config_path)?;
         library.update_library_extra_info(library.song_paths_info()?, true, true)?;
     } else if let Some(sub_m) = matches.subcommand_matches("playlist") {
-        let song_path = sub_m.get_one::<&str>("SONG_PATH").unwrap();
+        let song_path = sub_m.get_one::<String>("SONG_PATH").unwrap();
         let config_path = sub_m.get_one::<String>("config-path").map(PathBuf::from);
         let playlist_length = sub_m.get_one("playlist-length").unwrap();
 


### PR DESCRIPTION
Currently, if you try to do `library playlist $SONG`, clap panics with the following error:

```
thread 'main' panicked at examples/library.rs:189:31:
Mismatch between definition and access of `SONG_PATH`. Could not downcast to &str, need to downcast to alloc::string::String
```

Use a `String` instead of a `&str`, which does not panic.

Tested by building using `cargo build --features=serde,ffmpeg,library --release --example=library` (and the same operations with `library_extra_info`)