### PR TITLE
Add optional 'analysis' feature gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,30 +13,34 @@ readme = "README.md"
 exclude = ["data/"]
 
 [package.metadata.docs.rs]
-features = ["bliss-audio-aubio-rs/rustdoc", "library", "ffmpeg"]
+features = ["bliss-audio-aubio-rs/rustdoc", "library", "ffmpeg", "analysis"]
 no-default-features = true
 
 [features]
-default = ["ffmpeg", "aubio-static"]
+default = ["analysis", "ffmpeg", "aubio-static"]
+# Enable audio analysis (requires aubio + rustfft). Disable this if you only need
+# the playlist/distance math (Song, Analysis, NUMBER_FEATURES, playlist module).
+analysis = ["dep:bliss-audio-aubio-rs", "dep:rustfft"]
 # Enable song decoding with ffmpeg. Activated by default, and needed for
 # almost all use-cases, disable it at your own risk!
 # It is only useful if you want to implement the decoding of the tracks yourself
 # and just feed them to bliss, so you don't depend on ffmpeg.
 # TODO make ffmpeg a test-dep
 ffmpeg = ["dep:ffmpeg-next", "dep:ffmpeg-sys-next"]
-aubio-static = ["bliss-audio-aubio-rs/static"]
+aubio-static = ["analysis", "bliss-audio-aubio-rs/static"]
 # Build ffmpeg instead of using the host's.
 build-ffmpeg = ["ffmpeg-next/build"]
 ffmpeg-static = ["ffmpeg-next/static"]
 # Build for raspberry pis
 rpi = ["ffmpeg-next/rpi"]
 # Use if you get "No prebuilt bindings. Try use `bindgen` feature"
-update-aubio-bindings = ["bliss-audio-aubio-rs/bindgen"]
+update-aubio-bindings = ["analysis", "bliss-audio-aubio-rs/bindgen"]
 # Use if you want to build python bindings with maturin.
-python-bindings = ["bliss-audio-aubio-rs/fftw3"]
+python-bindings = ["analysis", "bliss-audio-aubio-rs/fftw3"]
 # Enable the benchmarks with `cargo +nightly bench --features=bench`
-bench = ["dep:criterion"]
+bench = ["analysis", "dep:criterion"]
 library = [
+    "analysis",
     "serde",
     "dep:rusqlite",
     "dep:dirs",
@@ -80,7 +84,7 @@ symphonia-aiff = ["symphonia", "symphonia/aiff", "symphonia/pcm"]
 [dependencies]
 # Until https://github.com/aubio/aubio/issues/336 is somehow solved
 # Hopefully we'll be able to use the official aubio-rs at some point.
-bliss-audio-aubio-rs = "0.2.4"
+bliss-audio-aubio-rs = { version = "0.2.4", optional = true }
 ffmpeg-next = { version = "8.0.0", optional = true }
 ffmpeg-sys-next = { version = "8.0.1", optional = true, default-features = false }
 log = "0.4.17"
@@ -90,7 +94,7 @@ ndarray = { version = "0.16.1", features = ["rayon"] }
 ndarray-stats = "0.6.0"
 noisy_float = "0.2.0"
 adler32 = "1.0.2"
-rustfft = "6.1.0"
+rustfft = { version = "6.1.0", optional = true }
 thiserror = "2.0.12"
 strum = "0.27.1"
 strum_macros = "0.27.1"

--- a/src/cue.rs
+++ b/src/cue.rs
@@ -7,13 +7,21 @@
 //! and [CueInfo], which is a struct stored in [Song] to keep track of the CUE information
 //! the song was extracted from.
 
+#[cfg(feature = "analysis")]
 use crate::song::decoder::Decoder as DecoderTrait;
+#[cfg(feature = "analysis")]
 use crate::{Analysis, AnalysisOptions, BlissError, BlissResult, Song, SAMPLE_RATE};
+#[cfg(feature = "analysis")]
 use rcue::cue::{Cue, Track};
+#[cfg(feature = "analysis")]
 use rcue::parser::parse_from_file;
+#[cfg(feature = "analysis")]
+use std::marker::PhantomData;
+#[cfg(feature = "analysis")]
 use std::path::Path;
+use std::path::PathBuf;
+#[cfg(feature = "analysis")]
 use std::time::Duration;
-use std::{marker::PhantomData, path::PathBuf};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
@@ -30,6 +38,7 @@ pub struct CueInfo {
     pub audio_file_path: PathBuf,
 }
 
+#[cfg(feature = "analysis")]
 /// A struct to handle CUEs with bliss.
 /// Use either [analyze_paths](crate::decoder::Decoder::analyze_paths), which takes care of CUE files
 /// automatically, or [songs_from_path](BlissCue::songs_from_path) to return a list
@@ -40,6 +49,7 @@ pub struct BlissCue<D: ?Sized> {
     decoder: PhantomData<D>,
 }
 
+#[cfg(feature = "analysis")]
 #[allow(missing_docs)]
 #[derive(Default, Debug, PartialEq, Clone)]
 struct BlissCueFile {
@@ -53,6 +63,7 @@ struct BlissCueFile {
     audio_file_path: PathBuf,
 }
 
+#[cfg(feature = "analysis")]
 impl<D: ?Sized + DecoderTrait> BlissCue<D> {
     /// Analyze songs from a CUE file, extracting individual [Song] objects
     /// for each individual song.
@@ -155,6 +166,7 @@ impl<D: ?Sized + DecoderTrait> BlissCue<D> {
     }
 }
 
+#[cfg(feature = "analysis")]
 impl BlissCueFile {
     fn create_song(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,15 +84,15 @@ pub mod library;
 pub mod playlist;
 mod song;
 
-#[cfg(not(feature = "bench"))]
+#[cfg(all(feature = "analysis", not(feature = "bench")))]
 mod chroma;
-#[cfg(not(feature = "bench"))]
+#[cfg(all(feature = "analysis", not(feature = "bench")))]
 mod misc;
-#[cfg(not(feature = "bench"))]
+#[cfg(all(feature = "analysis", not(feature = "bench")))]
 mod temporal;
-#[cfg(not(feature = "bench"))]
+#[cfg(all(feature = "analysis", not(feature = "bench")))]
 mod timbral;
-#[cfg(not(feature = "bench"))]
+#[cfg(all(feature = "analysis", not(feature = "bench")))]
 mod utils;
 
 #[cfg(feature = "bench")]
@@ -118,7 +118,9 @@ extern crate serde;
 use strum::EnumCount;
 use thiserror::Error;
 
-pub use song::{decoder, Analysis, AnalysisIndex, AnalysisOptions, Song, NUMBER_FEATURES};
+#[cfg(feature = "analysis")]
+pub use song::decoder;
+pub use song::{Analysis, AnalysisIndex, AnalysisOptions, Song, NUMBER_FEATURES};
 
 #[allow(dead_code)]
 /// The number of channels the raw samples must have to be analyzed by bliss-rs

--- a/src/song/mod.rs
+++ b/src/song/mod.rs
@@ -12,12 +12,18 @@
 extern crate ffmpeg_next as ffmpeg;
 extern crate ndarray;
 
+#[cfg(feature = "analysis")]
 use crate::chroma::ChromaDesc;
 use crate::cue::CueInfo;
+#[cfg(feature = "analysis")]
 use crate::misc::LoudnessDesc;
+#[cfg(feature = "analysis")]
 use crate::temporal::BPMDesc;
+#[cfg(feature = "analysis")]
 use crate::timbral::{SpectralDesc, ZeroCrossingRateDesc};
-use crate::{BlissError, BlissResult, FeaturesVersion, SAMPLE_RATE};
+#[cfg(feature = "analysis")]
+use crate::SAMPLE_RATE;
+use crate::{BlissError, BlissResult, FeaturesVersion};
 use core::ops::Index;
 use ndarray::{arr1, Array1};
 use std::fmt;
@@ -29,6 +35,7 @@ use std::time::Duration;
 use strum::IntoEnumIterator;
 use strum_macros::{EnumCount, EnumIter};
 
+#[cfg(feature = "analysis")]
 pub mod decoder;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -346,6 +353,7 @@ impl Analysis {
     }
 }
 
+#[cfg(feature = "analysis")]
 impl Song {
     /**
      * Analyze a song decoded in `sample_array`. This function should NOT
@@ -495,6 +503,7 @@ mod tests {
     #[cfg(feature = "ffmpeg")]
     use std::path::Path;
 
+    #[cfg(feature = "analysis")]
     #[test]
     fn test_analysis_too_small() {
         let error = Song::analyze(&[0.]).unwrap_err();


### PR DESCRIPTION
Gate all audio analysis dependencies (aubio-rs, rustfft, ffmpeg) behind an optional 'analysis' feature flag. The feature is enabled by default, so this is a non-breaking change for existing users.

Crates that only need the playlist/distance functionality (e.g. a mixing server that reads pre-computed features from a database and never decodes audio) can now depend on bliss-audio with `default-features = false` to avoid pulling in the heavy native analysis dependencies.